### PR TITLE
Add preventUnselectOne option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,11 @@ There is possibility to force refesh data by pushing <kbd>Alt</kbd> in the momen
   + 0 - selection disabled,
   + -1 - unlimited selection.    
 
++ `preventUnselectOne` (Integer) - Depending on `selectLimit` parameter. Work only if `selectLimit` = 1. Define whether it's possible to unselect node if `selectLimit` = 1.
+  + 0 (default) - can unselect
+  + 1 - unselect not happening.
+  + 2 - Similarly repeat select action with execute `onSelect` if defined. 
+
 + `nodeIndent` (Integer) - Distance between node and its container. The value is multiplied, depending on node level.
 
 + `nodeLevel` (Integer)

--- a/src/js/bootstrap-gtreetable.js
+++ b/src/js/bootstrap-gtreetable.js
@@ -406,7 +406,8 @@
         
         attachEvents: function () {
             var that = this,
-                selectLimit = parseInt(this.manager.options.selectLimit);
+                selectLimit = parseInt(this.manager.options.selectLimit),
+                preventUnselectOne = parseInt(this.manager.options.preventUnselectOne);
             
             this.$node.mouseover(function () {
                 if (!(that.manager.options.draggable === true && that.manager.isNodeDragging() === true)) {
@@ -423,12 +424,17 @@
 
             if (isNaN(selectLimit) === false && (selectLimit > 0 || selectLimit === -1) ) {
                 this.$name.click(function (e) {
-                    if (that.isSelected()) {
+                    var preventUnselectCheck = 0;
+                    if (selectLimit === 1 && isNaN(preventUnselectOne) === false && preventUnselectOne > 0) {
+                        preventUnselectCheck = preventUnselectOne;
+                    }
+
+                    if (that.isSelected() && preventUnselectCheck === 0 ) {
                         if ($.isFunction(that.manager.options.onUnselect)) {
                             that.manager.options.onUnselect(that);
                         }
                         that.isSelected(false);
-                    } else {
+                    } else if ( !that.isSelected() || preventUnselectCheck === 2 ) {
                         var selectedNodes = that.manager.getSelectedNodes();
                         if (selectLimit === 1 && selectedNodes.length === 1) {
                             selectedNodes[0].isSelected(false);
@@ -1160,6 +1166,7 @@
         cache: 2,
         readonly: false,
         selectLimit: 1,
+        preventUnselectOne: 0,
         rootLevel: 0,        
         manyroots: false,
         draggable: false,


### PR DESCRIPTION
This options added for more flexible usage scenarios. With only one allow selection
(selectLimit == 1) can be denied unselection and, as variant, not only denied unselection,
but repeat selection action.